### PR TITLE
Fixes a crash when trying to regenerate an offsets file containing a …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## v0.1.4
+* Fixes a crash when trying to regenerate an offsets file containing a non-semantic branch name.
+
 ## v0.1.3
 * Changes in the [input file JSON schema](examples/input_file.json):
   - The `"branch"` property will override the `"versions"` constraint and will directly

--- a/examples/usage.go
+++ b/examples/usage.go
@@ -13,7 +13,7 @@ func main() {
 	}
 	structFields := [][]string{
 		{"google.golang.org/grpc/internal/transport.Stream", "method", "1.16.7"},
-		{"google.golang.org/genproto/googleapis/rpc/status.Status", "Code", "0.0.0"},
+		{"google.golang.org/genproto/googleapis/rpc/status.Status", "Code", "v0.1.0"},
 	}
 	for _, sf := range structFields {
 		structName, fieldName, version := sf[0], sf[1], sf[2]

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -76,7 +76,7 @@ func (c *Cache) IsAllInCache(version string, dataMembers []*binary.DataMember) (
 // searchOffset searches an offset from the newest field whose version
 // is lower than or equal to the target version
 func searchOffset(field offsets.Field, targetVersion string) (uint64, bool) {
-	target := versions.MustParse(targetVersion)
+	target := versions.OrZero(targetVersion)
 
 	// Search from the newest version
 	for o := len(field.Offsets) - 1; o >= 0; o-- {

--- a/pkg/versions/tools.go
+++ b/pkg/versions/tools.go
@@ -3,7 +3,7 @@ package versions
 import "github.com/hashicorp/go-version"
 
 func Between(target, lowerBound, higherBound string) bool {
-	v := MustParse(target)
+	v := OrZero(target)
 
 	return v.GreaterThanOrEqual(MustParse(lowerBound)) &&
 		v.LessThanOrEqual(MustParse(higherBound))


### PR DESCRIPTION
…non-semantic branch name.